### PR TITLE
Updated Swift course link to an updated version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 #### Languages
 * https://www.udacity.com/course/developing-android-apps-with-kotlin--ud9012
-* https://itunes.apple.com/us/course/developing-ios-11-apps-with-swift/id1309275316 (let’s hope for the updated version)
+* https://cs193p.sites.stanford.edu
 
 #### Dart
 * https://pub.dev/packages/freezed


### PR DESCRIPTION
The previous link was a course focused on iOS 11 and it was only available using the app iTunes U (which is only available on iPhone and iPad devices).

Stanford created a new course last year (https://cs193p.sites.stanford.edu) which is on their website and YouTube channel, with updated examples and supporting latest Xcode and iOS versions, so it would be good to have this link updated on this roadmap.